### PR TITLE
Fix npm issue to have git always use https

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -56,3 +56,7 @@ else
   puts "       !!!! No valid Github user found with GITHUB_AUTH_TOKEN: '#{github_token}'"
   exit 1
 end
+
+##
+# Set github config to always use https
+`git config --global url."https://".insteadOf git://`


### PR DESCRIPTION
Recent changes to npm and/or Github have caused npm 6 to take a very long time to resolve github dependencies, likely due to the git protocol being no longer supported by Github

https://github.com/npm/cli/issues/4896
https://github.blog/2021-09-01-improving-git-protocol-security-github/
https://stackoverflow.com/questions/19317264/does-github-support-git-protocol-for-pull/69812472#69812472

This forces all git interactions to be over https instead of the git protocol